### PR TITLE
Fix Vehicle Spawner for fueler

### DIFF
--- a/client/jobs/fueler.lua
+++ b/client/jobs/fueler.lua
@@ -120,7 +120,7 @@ Config.Jobs.fueler = {
 		},
 
 		VehicleSpawnPoint = {
-			Pos = {x = 580.54, y = -2309.70, z = 4.90},
+			Pos = {x = 570.54, y = -2309.70, z = 4.90},
 			Size = {x = 3.0, y = 3.0, z = 1.0},
 			Marker = -1,
 			Blip = false,


### PR DESCRIPTION
The actual spawn is in the middle of a NPC parking, the new point is in the middle of the road where no NPC should be.