### PR TITLE
Fix the Hint displaying before the circle

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -364,7 +364,7 @@ Citizen.CreateThread(function()
 		local zone     = nil
 
 		for k,v in pairs(Config.PublicZones) do
-			if GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < v.Size.x then
+			if GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < v.Size.x/2 then
 				isInPublicMarker = true
 				position = v.Teleport
 				zone = v


### PR DESCRIPTION
The hint to click to the "E" appears too fast. This is because v.Size.x is the diameter. If you want to compare from the center of the circle, you must divide it by 2